### PR TITLE
mkfs: exfat_create_bitmap: fix garbage in allocated bitmap

### DIFF
--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -328,6 +328,8 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd)
 	if (!bitmap)
 		return -1;
 
+	memset(bitmap, 0, finfo.bitmap_byte_len);
+
 	for (i = 0; i < finfo.used_clu_cnt - EXFAT_FIRST_CLUSTER; i++)
 		exfat_set_bit(bd, bitmap, i);
 
@@ -338,6 +340,8 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd)
 			nbytes, finfo.bitmap_byte_len);
 		return -1;
 	}
+
+	free(bitmap);
 
 	return 0;
 }


### PR DESCRIPTION
Allocating memory without zeroing leads to garbage in bitmap and lost "preallocated" clusters