### PR TITLE
mkfs: zero the reserved fields of directory entries

### DIFF
--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -337,7 +337,7 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd)
 static int exfat_create_root_dir(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
-	struct exfat_dentry ed[3];
+	struct exfat_dentry ed[3] = {0};
 	int dentries_len = sizeof(struct exfat_dentry) * 3;
 	int nbytes;
 


### PR DESCRIPTION
From MS exfat specification, the reserved field shall initialize to zero and should not use for any purpose.

This commit zeroes the reserved fields of Allocation Bitmap, Up-case Table, Volume Label entries.

Signed-off-by: Yuezhang Mo <Yuezhang.Mo@sony.com>
Reviewed-by: Andy Wu <Andy.Wu@sony.com>
Reviewed-by: Aoyama Wataru <wataru.aoyama@sony.com>